### PR TITLE
Added support for weather sensors

### DIFF
--- a/pytrafikverket.pyproj
+++ b/pytrafikverket.pyproj
@@ -51,6 +51,9 @@
     <Compile Include="pytrafikverket\trafikverket_train.py">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="pytrafikverket\trafikverket_weather.py">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="pytrafikverket\__main__.py">
       <SubType>Code</SubType>
     </Compile>

--- a/pytrafikverket/__init__.py
+++ b/pytrafikverket/__init__.py
@@ -1,2 +1,3 @@
 from pytrafikverket.trafikverket import FilterOperation, SortOrder, FieldSort, Filter, FieldFilter, OrFilter, AndFilter, Trafikverket, NodeHelper
 from pytrafikverket.trafikverket_train import StationInfo, TrainStopStatus, TrainStop, TrafikverketTrain
+from pytrafikverket.trafikverket_weather import WeatherStationInfo, TrafikverketWeather

--- a/pytrafikverket/__main__.py
+++ b/pytrafikverket/__main__.py
@@ -4,11 +4,13 @@ import asyncio
 import aiohttp
 import async_timeout
 from pytrafikverket.trafikverket_train import TrafikverketTrain
+from pytrafikverket.trafikverket_weather import TrafikverketWeather
 from pytrafikverket.trafikverket import Trafikverket
 
 SEARCH_FOR_STATION = "search-for-station"
 GET_TRAIN_STOP = "get-train-stop"
 GET_NEXT_TRAIN_STOP = "get-next-train-stop"
+GET_WEATHER = "get-weather"
 
 async def async_main(loop):
     async with aiohttp.ClientSession(loop=loop) as session:
@@ -17,7 +19,8 @@ async def async_main(loop):
         parser.add_argument("-key", type=str)
         parser.add_argument("-method", choices=(SEARCH_FOR_STATION,
                                                 GET_TRAIN_STOP,
-                                                GET_NEXT_TRAIN_STOP))
+                                                GET_NEXT_TRAIN_STOP,
+                                                GET_WEATHER))
         parser.add_argument("-station", type=str)
         parser.add_argument("-from-station", type=str)
         parser.add_argument("-to-station", type=str)
@@ -26,6 +29,7 @@ async def async_main(loop):
         args = parser.parse_args()
 
         train_api = TrafikverketTrain(session, args.key)
+        weather_api = TrafikverketWeather(session, args.key)
         with async_timeout.timeout(10):
             if args.method == SEARCH_FOR_STATION:
                 if args.station is None:
@@ -62,6 +66,17 @@ async def async_main(loop):
                       "estimated time: %s, time: %s, state: %s" %
                       (train_stop.estimated_time_at_location, train_stop.time_at_location,
                        train_stop.get_state()))
+            elif args.method == GET_WEATHER:
+                if args.station is None:
+                    raise ValueError("-station is required with name of Weather station (ex. -station \"Nöbbele\")")
+                weather = await weather_api.async_get_weather(args.station)
+                print("Name: %s, id: %s, road temp: %s , air temp: %s, " %
+                      (weather.station_name, weather.station_id, weather.road_temp, weather.air_temp) + 
+                      "humidity: %s, precipitation: %s, wind direction %s degrees / " %
+                      (weather.humidity, weather.precipitationtype, weather.winddirection) +
+                      "%s, wind force: %s m/s (10 min avg)" %
+                      (weather.winddirectiontext, weather.windforce))
+
 
 
 def main():

--- a/pytrafikverket/trafikverket_weather.py
+++ b/pytrafikverket/trafikverket_weather.py
@@ -1,0 +1,59 @@
+import asyncio
+import aiohttp
+from pytrafikverket.trafikverket import Trafikverket, FieldFilter, \
+                                        FilterOperation, NodeHelper
+
+class WeatherStationInfo(object):
+    """Fetch Weather data from specified weather station"""
+
+    required_fields = ["Name", "Id", "Measurement.Road.Temp", "Measurement.Air.Temp", 
+                       "Measurement.Air.RelativeHumidity", "Measurement.Precipitation.Type", 
+                       "Measurement.Wind.Direction", "Measurement.Wind.DirectionText", "Measurement.Wind.Force" ]
+
+    def __init__(self, station_name: str, station_id: str, road_temp: float, air_temp: float, 
+                 humidity: float, precipitationtype: str, winddirection: float, 
+                 winddirectiontext: str, windforce: float):
+        self.station_name = station_name
+        self.station_id = station_id
+        self.road_temp = road_temp
+        self.air_temp = air_temp
+        self.humidity = humidity
+        self.precipitationtype = precipitationtype
+        self.winddirection = winddirection
+        self.winddirectiontext = winddirectiontext
+        self.windforce = windforce
+
+    @classmethod
+    def from_xml_node(cls, node):
+        node_helper = NodeHelper(node)
+        station_name = node_helper.get_text("Name")
+        station_id = node_helper.get_text("Id")
+        road_temp = node_helper.get_text("Measurement/Air/Temp")
+        air_temp = node_helper.get_text("Measurement/Road/Temp")
+        humidity = node_helper.get_text("Measurement/Air/RelativeHumidity")
+        precipitationtype = node_helper.get_text("Measurement/Precipitation/Type")
+        winddirection = node_helper.get_text("Measurement/Wind/Direction")
+        winddirectiontext = node_helper.get_text("Measurement/Wind/DirectionText")
+        windforce = node_helper.get_text("Measurement/Wind/Force")
+        return cls(station_name, station_id, road_temp, air_temp, humidity, precipitationtype, winddirection, winddirectiontext, windforce)
+
+
+class TrafikverketWeather(object):
+    """class used to communicate with trafikverket's weather api"""
+
+    def __init__(self, client_session:aiohttp.ClientSession, api_key:str):
+        """Initialize Weather object"""
+        self._api = Trafikverket(client_session, api_key)
+    
+    async def async_get_weather(self, location_name: str) -> WeatherStationInfo:
+        weather_stations = await self._api.async_make_request("WeatherStation",
+                                                      WeatherStationInfo.required_fields,
+                                                      [FieldFilter(FilterOperation.equal,
+                                                                   "Name",
+                                                                   location_name)])
+        if len(weather_stations) == 0:
+            raise ValueError("Could not find a weather station with the specified name")
+        if len(weather_stations) > 1:
+            raise ValueError("Found multiple weather stations with the specified name")
+
+        return WeatherStationInfo.from_xml_node(weather_stations[0])

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="pytrafikverket",
-    version="0.1.5.7",
+    version="0.1.5.8",
     description="api for trafikverket in sweden",
     url='https://github.com/AnderssonPeter/pytrafikverket',
     author="Peter Andersson",


### PR DESCRIPTION
Added support to retreive weather sensor data from trafikverket road sensors.
Verified with pylint and simulated successfully with cli test.
Bumped version from 1.5.7 to 1.5.8

Weatherstation:
https://api.trafikinfo.trafikverket.se/API/Model

Stations with names: 
https://www.trafikverket.se/trafikinformation/vag/?TrafficType=personalTraffic&map=1/606442.17/6886316.22/&Layers=RoadWeather%2b

Example CLI for weatherstations:
-key [api_key here] -method get-weather -station "Upplid"